### PR TITLE
Updated pom.xml to autoresolve package declarations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,6 @@
   <artifactId>mtip_csm_plugin</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <build>
-    <sourceDirectory>src</sourceDirectory>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
`<sourceDirectory>src</sourceDirectory>` causes package import errors due to mismatched declarations